### PR TITLE
Better Paths

### DIFF
--- a/hurq.sh
+++ b/hurq.sh
@@ -3,23 +3,27 @@
 USER_ID=
 CHANNEL_ID=
 CHANNEL_TYPE=1
+
 CACHE=videos.txt
 HASH_PATH=~/hurq-hash.txt
+VIDEO_PATH=~/hurq/videos
 
 ipfs pin ls --type recursive | cut -d' ' -f1 | xargs -n1 ipfs pin rm
 ipfs repo gc
 
+mkdir -p $VIDEO_PATH
+
 if [ "$CHANNEL_TYPE" = "0" ]
 then
 	CHANNEL_URL=https://www.youtube.com/channel/$CHANNEL_ID/videos
-	CHANNEL_DIR=$CHANNEL_ID
-	yt-dlp -S "+res:720,ext" -ciw --download-archive $CACHE $CHANNEL_URL -o '%(channel_id)s/%(title)s.%(ext)s'
+	CHANNEL_DIR="${VIDEO_PATH}/${CHANNEL_ID}"
+	yt-dlp -S "+res:720,ext" -ciw --download-archive $CACHE $CHANNEL_URL -P $VIDEO_PATH -o '%(channel_id)s/%(title)s.%(ext)s'
 fi
 if [ "$CHANNEL_TYPE" = "1" ]
 then
 	CHANNEL_URL=https://www.youtube.com/user/$USER_ID/videos
-	CHANNEL_DIR=$USER_ID
-	yt-dlp -S "+res:720,ext" -ciw --download-archive $CACHE $CHANNEL_URL -o '%(channel)s/%(title)s.%(ext)s'
+	CHANNEL_DIR="${VIDEO_PATH}/${USER_ID}"
+	yt-dlp -S "+res:720,ext" -ciw --download-archive $CACHE $CHANNEL_URL -P $VIDEO_PATH -o '%(channel)s/%(title)s.%(ext)s'
 fi
 
 ipfs add -r $CHANNEL_DIR

--- a/hurq.sh
+++ b/hurq.sh
@@ -4,6 +4,7 @@ USER_ID=
 CHANNEL_ID=
 CHANNEL_TYPE=1
 CACHE=videos.txt
+HASH_PATH=~/hurq-hash.txt
 
 ipfs pin ls --type recursive | cut -d' ' -f1 | xargs -n1 ipfs pin rm
 ipfs repo gc
@@ -22,4 +23,4 @@ then
 fi
 
 ipfs add -r $CHANNEL_DIR
-ipfs pin ls --type recursive > ~/hurq-hash.txt
+ipfs pin ls --type recursive > $HASH_PATH


### PR DESCRIPTION
Fulfills Issue #2 by allowing users to specify their own paths via the `HASH_PATH` and `VIDEO_PATH` variables.

## New

- adds `HASH_PATH` to specify path & filename for IPFS hash output file
- adds `VIDEO_PATH` to specify path for videos to be downloaded into prior to IPFS upload & pinning

## Updated

none

## Removed

none