### PR TITLE
Improve pre-run cleanup

### DIFF
--- a/hurq.sh
+++ b/hurq.sh
@@ -8,6 +8,11 @@ then
 	ipfs repo gc
 fi
 
+if [[ -f "$HASH_PATH" ]]
+then
+	rm $HASH_PATH
+fi
+
 mkdir -p $VIDEO_PATH
 
 if [ "$CHANNEL_TYPE" = "0" ]

--- a/hurq.sh
+++ b/hurq.sh
@@ -2,8 +2,11 @@
 
 source config.sh
 
-ipfs pin ls --type recursive | cut -d' ' -f1 | xargs -n1 ipfs pin rm
-ipfs repo gc
+if [[ $(ipfs pin ls --type recursive) ]]
+then
+	ipfs pin ls --type recursive | cut -d' ' -f1 | xargs -n1 ipfs pin rm
+	ipfs repo gc
+fi
 
 mkdir -p $VIDEO_PATH
 


### PR DESCRIPTION
Fulfills issue #4 by improving the pre-run cleanup.

## New

- adds check for whether recursive IPFS pins already exist before running the command to delete them
- deletes output hash file if necessary

## Updated

none

## Removed

none