### PR TITLE
Ignore Vim swap files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 videos.txt
 urq.txt
 config.sh
+*.sw*


### PR DESCRIPTION
Resolves issue #12 by adding `vim` swap files to `.gitignore`.

## New

- added vim swap files to `.gitignore`

## Updated

none

## Removed

none