### PR TITLE
Add support for /c/ channels

### DIFF
--- a/example-config.sh
+++ b/example-config.sh
@@ -1,7 +1,6 @@
 # channel data
 CHANNEL_TYPE=1				# 0 to use CHANNEL_ID, 1 to use USER_ID
-CHANNEL_ID=UCDFD8RdIL2FxNfkKkus5RSQ	# channel ID - typically used on smaller or nonverified channels
-USER_ID=vekchannel			# user ID - typically used for larger or verified channels
+CHANNEL_ID=UCDFD8RdIL2FxNfkKkus5RSQ	# the ID from the channer/user URL
 
 # paths
 CACHE=~/hurq/downloaded-videos.txt	# path for the list of already downloaded videos

--- a/example-config.sh
+++ b/example-config.sh
@@ -1,6 +1,6 @@
 # channel data
-CHANNEL_TYPE=1				# 0 to use CHANNEL_ID, 1 to use USER_ID
-CHANNEL_ID=UCDFD8RdIL2FxNfkKkus5RSQ	# the ID from the channer/user URL
+CHANNEL_TYPE=1				# 0 for CHANNEL_IDs from /channel/, 1 for CHANNEL_IDs from /c/, 2 for CHANNEL_IDs from /user/
+CHANNEL_ID=UCDFD8RdIL2FxNfkKkus5RSQ	# channel ID - typically one of 3 types: a /channel/, a /c/, or a /user/
 
 # paths
 CACHE=~/hurq/downloaded-videos.txt	# path for the list of already downloaded videos

--- a/hurq.sh
+++ b/hurq.sh
@@ -23,6 +23,12 @@ then
 fi
 if [ "$CHANNEL_TYPE" = "1" ]
 then
+	CHANNEL_URL=https://www.youtube.com/c/$USER_ID/videos
+	CHANNEL_DIR="${VIDEO_PATH}/${CHANNEL_ID}"
+	yt-dlp -S "+res:720,ext" -ciw --download-archive $CACHE $CHANNEL_URL -P $VIDEO_PATH -o '%(channel)s/%(title)s.%(ext)s'
+fi
+if [ "$CHANNEL_TYPE" = "2" ]
+then
 	CHANNEL_URL=https://www.youtube.com/user/$USER_ID/videos
 	CHANNEL_DIR="${VIDEO_PATH}/${CHANNEL_ID}"
 	yt-dlp -S "+res:720,ext" -ciw --download-archive $CACHE $CHANNEL_URL -P $VIDEO_PATH -o '%(channel)s/%(title)s.%(ext)s'

--- a/hurq.sh
+++ b/hurq.sh
@@ -24,7 +24,7 @@ fi
 if [ "$CHANNEL_TYPE" = "1" ]
 then
 	CHANNEL_URL=https://www.youtube.com/user/$USER_ID/videos
-	CHANNEL_DIR="${VIDEO_PATH}/${USER_ID}"
+	CHANNEL_DIR="${VIDEO_PATH}/${CHANNEL_ID}"
 	yt-dlp -S "+res:720,ext" -ciw --download-archive $CACHE $CHANNEL_URL -P $VIDEO_PATH -o '%(channel)s/%(title)s.%(ext)s'
 fi
 


### PR DESCRIPTION
Resolves #8 by adding support for channels accessed via `/c/` in the YouTube URL and cleans up the associated config variables.

## New

- added support for `/c/` channels

## Updated

- updated case structures to use `CHANNEL_ID` variable

## Removed

- removed `USER_ID` variable