### PR TITLE
Fix CHANNEL_URL variables

### DIFF
--- a/hurq.sh
+++ b/hurq.sh
@@ -23,13 +23,13 @@ then
 fi
 if [ "$CHANNEL_TYPE" = "1" ]
 then
-	CHANNEL_URL=https://www.youtube.com/c/$USER_ID/videos
+	CHANNEL_URL=https://www.youtube.com/c/$CHANNEL_ID/videos
 	CHANNEL_DIR="${VIDEO_PATH}/${CHANNEL_ID}"
 	yt-dlp -S "+res:720,ext" -ciw --download-archive $CACHE $CHANNEL_URL -P $VIDEO_PATH -o '%(channel)s/%(title)s.%(ext)s'
 fi
 if [ "$CHANNEL_TYPE" = "2" ]
 then
-	CHANNEL_URL=https://www.youtube.com/user/$USER_ID/videos
+	CHANNEL_URL=https://www.youtube.com/user/$CHANNEL_ID/videos
 	CHANNEL_DIR="${VIDEO_PATH}/${CHANNEL_ID}"
 	yt-dlp -S "+res:720,ext" -ciw --download-archive $CACHE $CHANNEL_URL -P $VIDEO_PATH -o '%(channel)s/%(title)s.%(ext)s'
 fi


### PR DESCRIPTION
Resolves #16 by updating the `CHANNEL_URL` variables to use `CHANNEL_ID` instead of the old variables.

## New

none

## Updated

- changed the `CHANNEL_URL` variables to use `CHANNEL_ID`

## Removed

none