### PR TITLE
Support CLI flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 videos.txt
 urq.txt
-config.sh
 *.sw*

--- a/README.md
+++ b/README.md
@@ -15,8 +15,24 @@ Make sure you have your IPFS node [initialised](https://docs.ipfs.io/how-to/comm
 
 ## run
 
-Copy `example-config.sh` to `config.sh` & set configuration variables as appropriate. Information on what each variable does is in the comments of `example-config.sh`.
+`--channel-id` is the UID YouTube uses for identifying channels, typically a string following another string (one of 3 types: a `/channel/`, a `/c/`, or a `/user/`).
+
+`--channel-type` is the type of channel to downloaded from:
+
+ - 0 for `channel-id`s from the `/channel/` URL
+ - 1 for `channel-id`s from the `/c/` URL
+ - 2 for `channel-id`s from the `/user/` URL
+
+Examine the URL to find which `channel-type` is necessary.
+
+`--path` is the working directory hurq will store its files in.
 
 Ensure hurq.sh has the execute permission set.
 
-Run hurq.sh. The hash of the directory the archived channel lives in will be output to `~/hurq-hash.txt`.
+Run hurq.sh. The hash of the directory the archived channel lives in will be output to `hurq-hash.txt` in the `--path` directory specified.
+
+### examples
+
+Download the [BatzorigVaanchig](https://www.youtube.com/c/BatzorigVaanchig) channel:
+
+`./hurq.sh --channel-id BatzorigVaanchig --channel-type 1 --path /home/nartesfasrum/Videos/`

--- a/example-config.sh
+++ b/example-config.sh
@@ -3,6 +3,4 @@ CHANNEL_TYPE=1				# 0 for CHANNEL_IDs from /channel/, 1 for CHANNEL_IDs from /c/
 CHANNEL_ID=UCDFD8RdIL2FxNfkKkus5RSQ	# channel ID - typically one of 3 types: a /channel/, a /c/, or a /user/
 
 # paths
-CACHE=~/hurq/downloaded-videos.txt	# path for the list of already downloaded videos
-HASH_PATH=~/hurq/hurq-hash.txt		# path for the hurq hash output
-VIDEO_PATH=~/hurq/videos		# path to download videos into
+HURQ_PATH=~/hurq/videos			# path for hurq to work in

--- a/example-config.sh
+++ b/example-config.sh
@@ -1,6 +1,0 @@
-# channel data
-CHANNEL_TYPE=1				# 0 for CHANNEL_IDs from /channel/, 1 for CHANNEL_IDs from /c/, 2 for CHANNEL_IDs from /user/
-CHANNEL_ID=UCDFD8RdIL2FxNfkKkus5RSQ	# channel ID - typically one of 3 types: a /channel/, a /c/, or a /user/
-
-# paths
-HURQ_PATH=~/hurq/videos			# path for hurq to work in

--- a/hurq.sh
+++ b/hurq.sh
@@ -2,6 +2,10 @@
 
 source config.sh
 
+CACHE_PATH=$HURQ_PATH/downloaded-videos.txt
+HASH_PATH=$HURQ_PATH/hurq-hash.txt
+VIDEO_PATH=$HURQ_PATH/videos
+
 if [[ $(ipfs pin ls --type recursive) ]]
 then
 	ipfs pin ls --type recursive | cut -d' ' -f1 | xargs -n1 ipfs pin rm
@@ -19,19 +23,19 @@ if [ "$CHANNEL_TYPE" = "0" ]
 then
 	CHANNEL_URL=https://www.youtube.com/channel/$CHANNEL_ID/videos
 	CHANNEL_DIR="${VIDEO_PATH}/${CHANNEL_ID}"
-	yt-dlp -S "+res:720,ext" -ciw --download-archive $CACHE $CHANNEL_URL -P $VIDEO_PATH -o '%(channel_id)s/%(title)s.%(ext)s'
+	yt-dlp -S "+res:720,ext" -ciw --download-archive $CACHE_PATH $CHANNEL_URL -P $VIDEO_PATH -o '%(channel_id)s/%(title)s.%(ext)s'
 fi
 if [ "$CHANNEL_TYPE" = "1" ]
 then
 	CHANNEL_URL=https://www.youtube.com/c/$CHANNEL_ID/videos
 	CHANNEL_DIR="${VIDEO_PATH}/${CHANNEL_ID}"
-	yt-dlp -S "+res:720,ext" -ciw --download-archive $CACHE $CHANNEL_URL -P $VIDEO_PATH -o '%(channel)s/%(title)s.%(ext)s'
+	yt-dlp -S "+res:720,ext" -ciw --download-archive $CACHE_PATH $CHANNEL_URL -P $VIDEO_PATH -o '%(channel)s/%(title)s.%(ext)s'
 fi
 if [ "$CHANNEL_TYPE" = "2" ]
 then
 	CHANNEL_URL=https://www.youtube.com/user/$CHANNEL_ID/videos
 	CHANNEL_DIR="${VIDEO_PATH}/${CHANNEL_ID}"
-	yt-dlp -S "+res:720,ext" -ciw --download-archive $CACHE $CHANNEL_URL -P $VIDEO_PATH -o '%(channel)s/%(title)s.%(ext)s'
+	yt-dlp -S "+res:720,ext" -ciw --download-archive $CACHE_PATH $CHANNEL_URL -P $VIDEO_PATH -o '%(channel)s/%(title)s.%(ext)s'
 fi
 
 ipfs add -r $CHANNEL_DIR

--- a/hurq.sh
+++ b/hurq.sh
@@ -1,10 +1,36 @@
 #!/bin/bash
 
-source config.sh
+ARGS=$(getopt -a --options c:t:p: --long "channel-id:,channel-type:,path:" -- "$@")
+eval set -- "$ARGS"
 
-CACHE_PATH=$HURQ_PATH/downloaded-videos.txt
-HASH_PATH=$HURQ_PATH/hurq-hash.txt
-VIDEO_PATH=$HURQ_PATH/videos
+while true; do
+	case "$1" in
+		-c|--channel-id)
+			CHANNEL_ID="$2"
+			echo $CHANNEL_ID
+			shift 2;;
+		-t|--channel-type)
+			CHANNEL_TYPE="$2"
+			echo $CHANNEL_TYPE
+			shift 2;;
+		-p|--path)
+			HURQ_PATH="$2"
+			echo $HURQ_PATH
+			shift 2;;
+		--)
+			break;;
+		*)
+			printf "Unknown option %s\n" "$1"
+			exit 1;;
+	esac
+done
+
+CACHE_PATH=$HURQ_PATH/$CHANNEL_ID/downloaded-videos.txt
+HASH_PATH=$HURQ_PATH/$CHANNEL_ID/hurq-hash.txt
+VIDEO_PATH=$HURQ_PATH/$CHANNEL_ID/videos
+
+mkdir -p $HURQ_PATH
+mkdir -p $VIDEO_PATH
 
 if [[ $(ipfs pin ls --type recursive) ]]
 then
@@ -16,8 +42,6 @@ if [[ -f "$HASH_PATH" ]]
 then
 	rm $HASH_PATH
 fi
-
-mkdir -p $VIDEO_PATH
 
 if [ "$CHANNEL_TYPE" = "0" ]
 then


### PR DESCRIPTION
Fulfills issue #18 by adding support for CLI flags and removing support for the config file.

## New

- adds config flags `--channel-id`, `--channel-type`, & `--path`

## Updated

- simplified path variables
- updates `.gitignore` to remove unneeded exclusion of config files
- updates README to reflect new usage

## Removed

- removes ability to use config files